### PR TITLE
Fixing tests after the DAP Debugger.

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/DAPDebugger.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/DAPDebugger.java
@@ -318,6 +318,8 @@ public final class DAPDebugger implements IDebugProtocolClient {
         //some servers (e.g. the GraalVM DAP server) require the threadId to be always set, even if singleThread is set to false
         args.setThreadId(currentThreadId);
         args.setSingleThread(Boolean.FALSE);
+
+        continued();
         server.continue_(args);
     }
 

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/attach/Bundle.properties
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/attach/Bundle.properties
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 DAPAttachPanel.jLabel1.text=&Hostname:
 DAPAttachPanel.jLabel2.text=&Port:
 DAPAttachPanel.jLabel3.text=Connection &type:

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/attach/DAPAttachPanel.form
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/attach/DAPAttachPanel.form
@@ -1,5 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
 <Form version="1.5" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
   <NonVisualComponents>
     <Component class="javax.swing.JLabel" name="jLabel4">

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/ConnectionSpecTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/ConnectionSpecTest.java
@@ -121,7 +121,7 @@ public class ConnectionSpecTest {
             String reply = os.toString("UTF-8");
             String exp = "Pipe server listening at port ";
             assertTrue(reply, reply.startsWith(exp));
-            int port = Integer.parseInt(reply.substring(exp.length()));
+            int port = Integer.parseInt(reply.substring(exp.length(), reply.indexOf('\n', exp.length())));
             assertTrue("port is specified: " + port, port >= 1024);
             try (ConnectionSpec second = ConnectionSpec.parse("connect:" + port)) {
                 second.prepare("Pipe client", in, os, new LspSession(), ConnectionSpecTest::setCopy, ConnectionSpecTest::copy);


### PR DESCRIPTION
I was looking at https://github.com/apache/netbeans/pull/8098 - good job!

This PR:
- fixes the paperwork task, by adding license headers (assuming you'll agree with them)
- fixes the `ConnectionSpecTest`, by handling the ending newline
- making the `resume` method perform `continue`, which was missing ("step" methods already do that).

Please let me know what you think!