### PR TITLE
Attempting to do further cleanup the DAP debugger, as per comments by matthiasblaesing

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/DAPFrame.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/DAPFrame.java
@@ -25,7 +25,7 @@ import java.util.logging.Logger;
 import org.eclipse.lsp4j.debug.StackFrame;
 
 import org.netbeans.api.annotations.common.CheckForNull;
-import org.netbeans.modules.lsp.client.debugger.DAPDebugger.URLPathConvertor;
+import org.netbeans.modules.lsp.client.debugger.DAPDebugger.URIPathConvertor;
 import org.netbeans.spi.debugger.ui.DebuggingView.DVFrame;
 import org.netbeans.spi.debugger.ui.DebuggingView.DVThread;
 
@@ -38,11 +38,11 @@ public final class DAPFrame implements DVFrame {
 
     private static final Logger LOGGER = Logger.getLogger(DAPFrame.class.getName());
 
-    private final URLPathConvertor fileConvertor;
+    private final URIPathConvertor fileConvertor;
     private final DAPThread thread;
     private final StackFrame frame;
 
-    public DAPFrame(URLPathConvertor fileConvertor, DAPThread thread, StackFrame frame) {
+    public DAPFrame(URIPathConvertor fileConvertor, DAPThread thread, StackFrame frame) {
         this.fileConvertor = fileConvertor;
         this.thread = thread;
         this.frame = frame;
@@ -71,15 +71,11 @@ public final class DAPFrame implements DVFrame {
 
     @Override
     public URI getSourceURI() {
-        try {
-            //XXX: frame.getSource().getPath() may not work(!)
-            if (frame.getSource() == null || frame.getSource().getPath() == null) {
-                return null;
-            }
-            return new URI(fileConvertor.toURL(frame.getSource().getPath()));
-        } catch (URISyntaxException ex) {
+        //XXX: frame.getSource().getPath() may not work(!)
+        if (frame.getSource() == null || frame.getSource().getPath() == null) {
             return null;
         }
+        return fileConvertor.toURI(frame.getSource().getPath());
     }
 
     @Override

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/DAPStackTraceAnnotationHolder.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/DAPStackTraceAnnotationHolder.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.lsp.client.debugger;
 
-import java.util.logging.Logger;
 import javax.swing.SwingUtilities;
 
 import org.openide.text.Annotatable;
@@ -27,13 +26,11 @@ import org.openide.text.Line;
 import org.openide.text.Line.ShowOpenType;
 import org.openide.text.Line.ShowVisibilityType;
 
-public final class DAPUtils {
+public final class DAPStackTraceAnnotationHolder {
 
-    private static final Logger logger = Logger.getLogger(DAPUtils.class.getName());
+    private static DebuggerAnnotation[] currentAnnotations;
 
-    private static Object currentLine;
-
-    private DAPUtils() {
+    private DAPStackTraceAnnotationHolder() {
     }
 
     static synchronized void markCurrent (Annotatable[] annotatables) {
@@ -56,31 +53,32 @@ public final class DAPUtils {
         }
 
         // other lines
-        for (i = 1; i < k; i++)
-            if (annotatables [i] instanceof Line.Part)
+        for (i = 1; i < k; i++) {
+            if (annotatables [i] instanceof Line.Part) {
                 annotations [i] = new DebuggerAnnotation (
                     DebuggerAnnotation.CALL_STACK_FRAME_ANNOTATION_TYPE,
                     annotatables [i]
                 );
-            else
+            } else {
                 annotations [i] = new DebuggerAnnotation (
                     DebuggerAnnotation.CALL_STACK_FRAME_ANNOTATION_TYPE,
                     annotatables [i]
                 );
-        currentLine = annotations;
+            }
+        }
+
+        currentAnnotations = annotations;
 
         showLine(annotatables);
     }
 
     static synchronized void unmarkCurrent () {
-        if (currentLine != null) {
-
-//            ((DebuggerAnnotation) currentLine).detach ();
-            int i, k = ((DebuggerAnnotation[]) currentLine).length;
-            for (i = 0; i < k; i++) {
-                ((DebuggerAnnotation[]) currentLine) [i].detach ();
+        if (currentAnnotations != null) {
+            int k = currentAnnotations.length;
+            for (int i = 0; i < k; i++) {
+                currentAnnotations[i].detach();
             }
-            currentLine = null;
+            currentAnnotations = null;
         }
     }
 

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/DAPThread.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/DAPThread.java
@@ -179,7 +179,7 @@ public final class DAPThread implements DVThread {
         DAPFrame[] frames = getStack();
 
         if (frames.length == 0) {
-            DAPUtils.unmarkCurrent();
+            DAPStackTraceAnnotationHolder.unmarkCurrent();
             return ;
         }
 
@@ -196,7 +196,7 @@ public final class DAPThread implements DVThread {
               .filter(l -> l != currentLine)
               .forEach(stack::add);
 
-        DAPUtils.markCurrent(stack.toArray(Line[]::new));
+        DAPStackTraceAnnotationHolder.markCurrent(stack.toArray(Line[]::new));
     }
 
 }

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/LineBreakpointData.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/LineBreakpointData.java
@@ -18,5 +18,7 @@
  */
 package org.netbeans.modules.lsp.client.debugger;
 
-public record LineBreakpointData(String url, int lineNumber, String condition) {
+import java.net.URI;
+
+public record LineBreakpointData(URI uri, int lineNumber, String condition) {
 }

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/breakpoints/BreakpointAnnotationProvider.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/breakpoints/BreakpointAnnotationProvider.java
@@ -22,7 +22,6 @@ package org.netbeans.modules.lsp.client.debugger.breakpoints;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +39,6 @@ import org.openide.text.AnnotationProvider;
 import org.openide.text.Line;
 import org.openide.util.Lookup;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakListeners;
 import org.openide.util.WeakSet;
 
 
@@ -54,7 +52,6 @@ public final class BreakpointAnnotationProvider extends DebuggerManagerAdapter i
 
     private final Map<DAPLineBreakpoint, Set<Annotation>> breakpointToAnnotations = new IdentityHashMap<>();
     private final Set<FileObject> annotatedFiles = new WeakSet<>();
-    private Set<PropertyChangeListener> dataObjectListeners;
     private volatile boolean breakpointsActive = true;
     private final RequestProcessor annotationProcessor = new RequestProcessor("CPP BP Annotation Refresh", 1);
 
@@ -84,14 +81,7 @@ public final class BreakpointAnnotationProvider extends DebuggerManagerAdapter i
                         }
                     }
                 };
-                dobj.addPropertyChangeListener(WeakListeners.propertyChange(pchl, dobj));
-                synchronized (this) {
-                    if (dataObjectListeners == null) {
-                        dataObjectListeners = new HashSet<>();
-                    }
-                    // Prevent from GC.
-                    dataObjectListeners.add(pchl);
-                }
+                dobj.addPropertyChangeListener(pchl);
             }
             annotate(fo);
         }

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/breakpoints/BreakpointModel.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/breakpoints/BreakpointModel.java
@@ -25,7 +25,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.netbeans.api.debugger.DebuggerEngine;
 import org.netbeans.api.debugger.DebuggerManager;
 import org.netbeans.modules.lsp.client.debugger.DAPDebugger;
-import org.netbeans.modules.lsp.client.debugger.DAPUtils;
+import org.netbeans.modules.lsp.client.debugger.DAPStackTraceAnnotationHolder;
 
 import org.netbeans.spi.debugger.DebuggerServiceRegistration;
 import org.netbeans.spi.viewmodel.ModelEvent;
@@ -64,12 +64,7 @@ public final class BreakpointModel implements NodeModel {
             DAPLineBreakpoint breakpoint = (DAPLineBreakpoint) node;
             String nameExt;
             FileObject fileObject = breakpoint.getFileObject();
-            if (fileObject != null) {
-                nameExt = fileObject.getNameExt();
-            } else {
-                File file = new File(breakpoint.getFilePath());
-                nameExt = file.getName();
-            }
+            nameExt = fileObject.getNameExt();
             return nameExt + ":" + breakpoint.getLineNumber();
         }
         throw new UnknownTypeException (node);
@@ -92,7 +87,7 @@ public final class BreakpointModel implements NodeModel {
                 return DISABLED_LINE_BREAKPOINT;
             DAPDebugger debugger = getDebugger ();
             if ( debugger != null &&
-                 DAPUtils.contains (
+                 DAPStackTraceAnnotationHolder.contains (
                      debugger.getCurrentLine (),
                      breakpoint.getLine ()
                  )
@@ -117,7 +112,7 @@ public final class BreakpointModel implements NodeModel {
     throws UnknownTypeException {
         if (node instanceof DAPLineBreakpoint) {
             DAPLineBreakpoint breakpoint = (DAPLineBreakpoint) node;
-            return breakpoint.getFilePath() + ":" + breakpoint.getLineNumber();
+            return breakpoint.getFileObject().getPath() + ":" + breakpoint.getLineNumber();
         }
         throw new UnknownTypeException (node);
     }

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/breakpoints/BreakpointsReader.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/breakpoints/BreakpointsReader.java
@@ -46,25 +46,17 @@ public final class BreakpointsReader implements Properties.Reader {
         DAPLineBreakpoint b;
         int lineNumber = properties.getInt("lineNumber", 0) + 1;
         String url = properties.getString ("url", null);
-        if (url != null) {
-            FileObject fo;
-            try {
-                fo = URLMapper.findFileObject(new URL(url));
-            } catch (MalformedURLException ex) {
-                fo = null;
-            }
-            if (fo == null) {
-                // The user file is gone
-                return null;
-            }
-            b = DAPLineBreakpoint.create(fo, lineNumber);
-        } else {
-            String filePath = properties.getString ("filePath", null);
-            if (filePath == null) {
-                return null;
-            }
-            b = DAPLineBreakpoint.create(filePath, lineNumber);
+        FileObject fo;
+        try {
+            fo = URLMapper.findFileObject(new URL(url));
+        } catch (MalformedURLException ex) {
+            fo = null;
         }
+        if (fo == null) {
+            // The user file is gone
+            return null;
+        }
+        b = DAPLineBreakpoint.create(fo, lineNumber);
         b.setGroupName(
             properties.getString (Breakpoint.PROP_GROUP_NAME, "")
         );
@@ -92,10 +84,7 @@ public final class BreakpointsReader implements Properties.Reader {
     public void write (Object object, Properties properties) {
         DAPLineBreakpoint b = (DAPLineBreakpoint) object;
         FileObject fo = b.getFileObject();
-        if (fo != null) {
-            properties.setString("url", fo.toURL().toString());
-        }
-        properties.setString("filePath", b.getFilePath());
+        properties.setString("url", fo.toURL().toString());
         properties.setInt (
             "lineNumber",
             b.getLineNumber() - 1

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/breakpoints/DAPBreakpointConvertor.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/breakpoints/DAPBreakpointConvertor.java
@@ -28,7 +28,7 @@ public class DAPBreakpointConvertor implements BreakpointConvertor {
     @Override
     public void convert(Breakpoint b, ConvertedBreakpointConsumer breakpointConsumer) {
         if (b instanceof DAPLineBreakpoint lb) {
-            breakpointConsumer.lineBreakpoint("file://" + lb.getFilePath(), lb.getLineNumber(), lb.getCondition());
+            breakpointConsumer.lineBreakpoint(lb.getFileObject().toURI(), lb.getLineNumber(), lb.getCondition());
         }
     }
 

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/breakpoints/DAPLineBreakpoint.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/breakpoints/DAPLineBreakpoint.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.lsp.client.debugger.breakpoints;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +26,7 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.netbeans.api.annotations.common.CheckForNull;
-import org.netbeans.api.annotations.common.NullAllowed;
+import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.debugger.Breakpoint;
 import org.netbeans.api.debugger.DebuggerEngine;
 import org.netbeans.api.debugger.DebuggerManager;
@@ -54,27 +53,23 @@ public final class DAPLineBreakpoint extends Breakpoint {
 
     private final AtomicBoolean enabled = new AtomicBoolean(true);
     private final AtomicBoolean hidden = new AtomicBoolean(false);
-    @NullAllowed
     private final FileObject fileObject; // The user file that contains the breakpoint
-    private final String filePath; // Path of the file to which MI breakpoint is submitted
     private final int lineNumber; // The breakpoint line number
     private volatile String condition;
 
     private DAPLineBreakpoint (FileObject fileObject, String filePath, int lineNumber) {
         this.fileObject = fileObject;
-        this.filePath = filePath;
         this.lineNumber = lineNumber;
     }
 
     public static DAPLineBreakpoint create(Line line) {
         int lineNumber = line.getLineNumber() + 1;
         FileObject fileObject = line.getLookup().lookup(FileObject.class);
-        String filePath = FileUtil.toFile(fileObject).getAbsolutePath();
-        return new DAPLineBreakpoint(fileObject, filePath, lineNumber);
+        return create(fileObject, lineNumber);
     }
 
     /**
-     * Create a new CPP lite breakpoint based on a user file.
+     * Create a new DAP breakpoint based on a user file.
      * @param fileObject the file path of the breakpoint
      * @param lineNumber 1-based line number
      * @return a new breakpoint.
@@ -85,30 +80,13 @@ public final class DAPLineBreakpoint extends Breakpoint {
     }
 
     /**
-     * Create a new CPP lite breakpoint, that is not associated with a user file.
-     * @param filePath the file path of the breakpoint in the debuggee
-     * @param lineNumber 1-based line number
-     * @return a new breakpoint.
-     */
-    public static DAPLineBreakpoint create(String filePath, int lineNumber) {
-        return new DAPLineBreakpoint(null, filePath, lineNumber);
-    }
-
-    /**
-     * Get the file path of the breakpoint in the debuggee.
-     */
-    public String getFilePath() {
-        return filePath;
-    }
-
-    /**
      * 1-based line number.
      */
     public int getLineNumber() {
         return lineNumber;
     }
 
-    @CheckForNull
+    @NonNull
     public FileObject getFileObject() {
         return fileObject;
     }
@@ -189,10 +167,6 @@ public final class DAPLineBreakpoint extends Breakpoint {
         firePropertyChange (PROP_CONDITION, oldCondition, condition);
     }
 
-    public void setCPPValidity(VALIDITY validity, String reason) {
-        setValidity(validity, reason);
-    }
-
     /**
      * Gets value of hidden property.
      *
@@ -234,17 +208,12 @@ public final class DAPLineBreakpoint extends Breakpoint {
         }
 
         private FileObject getFile() {
-            return FileUtil.toFileObject(new File(filePath));
+            return getFileObject();
         }
 
         @Override
         public FileObject[] getFiles() {
-            FileObject fo = getFile();
-            if (fo != null) {
-                return new FileObject[] { fo };
-            } else {
-                return null;
-            }
+            return new FileObject[] { getFileObject() };
         }
 
         @Override

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/debuggingview/DebuggingActionsProvider.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/debuggingview/DebuggingActionsProvider.java
@@ -23,7 +23,7 @@ import javax.swing.Action;
 import org.netbeans.modules.lsp.client.debugger.DAPDebugger;
 import org.netbeans.modules.lsp.client.debugger.DAPFrame;
 import org.netbeans.modules.lsp.client.debugger.DAPThread;
-import org.netbeans.modules.lsp.client.debugger.DAPUtils;
+import org.netbeans.modules.lsp.client.debugger.DAPStackTraceAnnotationHolder;
 
 import org.netbeans.spi.debugger.ContextProvider;
 import org.netbeans.spi.debugger.DebuggerServiceRegistration;
@@ -208,7 +208,7 @@ public class DebuggingActionsProvider implements NodeActionsProvider {
     private static void goToSource(final DAPFrame frame) {
         Line currentLine = frame.location();
         if (currentLine != null) {
-            DAPUtils.showLine(new Line[] {currentLine});
+            DAPStackTraceAnnotationHolder.showLine(new Line[] {currentLine});
         }
     }
 

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/models/CallStackModel.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/models/CallStackModel.java
@@ -26,7 +26,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import javax.swing.Action;
 import org.netbeans.modules.lsp.client.debugger.DAPFrame;
 import org.netbeans.modules.lsp.client.debugger.DAPThread;
-import org.netbeans.modules.lsp.client.debugger.DAPUtils;
+import org.netbeans.modules.lsp.client.debugger.DAPStackTraceAnnotationHolder;
 
 import org.netbeans.spi.debugger.ContextProvider;
 import org.netbeans.spi.debugger.DebuggerServiceRegistration;
@@ -250,7 +250,7 @@ public class CallStackModel extends CurrentFrameTracker
         if (node instanceof DAPFrame) {
             Line line = ((DAPFrame) node).location();
             if (line != null) {
-                DAPUtils.showLine(new Line[] {line});
+                DAPStackTraceAnnotationHolder.showLine(new Line[] {line});
             }
             ((DAPFrame) node).makeCurrent();
             return;

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/spi/BreakpointConvertor.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/spi/BreakpointConvertor.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.lsp.client.debugger.spi;
 
+import java.net.URI;
 import java.util.List;
 import org.netbeans.modules.lsp.client.debugger.LineBreakpointData;
 import org.netbeans.modules.lsp.client.debugger.SPIAccessor;
@@ -35,8 +36,8 @@ public interface BreakpointConvertor {
             this.lineBreakpoints = lineBreakpoints;
         }
 
-        public void lineBreakpoint(String url, int lineNumber, String condition) {
-            lineBreakpoints.add(new LineBreakpointData(url, lineNumber, condition));
+        public void lineBreakpoint(URI uri, int lineNumber, String condition) {
+            lineBreakpoints.add(new LineBreakpointData(uri, lineNumber, condition));
         }
 
         static {

--- a/ide/lsp.client/test/unit/src/org/netbeans/modules/lsp/client/debugger/DebuggerTest.java
+++ b/ide/lsp.client/test/unit/src/org/netbeans/modules/lsp/client/debugger/DebuggerTest.java
@@ -92,7 +92,6 @@ public class DebuggerTest extends NbTestCase {
     private FileObject srcDir;
     private String srcDirURL;
     private FileObject testFile;
-    private String testFileURL;
 
     public DebuggerTest(String name) {
         super(name);
@@ -117,8 +116,8 @@ public class DebuggerTest extends NbTestCase {
 
         DebuggerManager manager = DebuggerManager.getDebuggerManager();
 
-        manager.addBreakpoint(DAPLineBreakpoint.create(testFileURL, 4));
-        DAPLineBreakpoint line6Breakpoint = DAPLineBreakpoint.create(testFileURL, 6);
+        manager.addBreakpoint(DAPLineBreakpoint.create(testFile, 4));
+        DAPLineBreakpoint line6Breakpoint = DAPLineBreakpoint.create(testFile, 6);
         manager.addBreakpoint(line6Breakpoint);
         int backendPort = startBackend();
         Socket socket = new Socket("localhost", backendPort);
@@ -154,7 +153,7 @@ public class DebuggerTest extends NbTestCase {
 
         //tweak breakpoints:
         manager.removeBreakpoint(line6Breakpoint);
-        manager.addBreakpoint(DAPLineBreakpoint.create(testFileURL, 7));
+        manager.addBreakpoint(DAPLineBreakpoint.create(testFile, 7));
         //continue to debugging - should finish at line 7, not 6:
         waitFor(true, () -> am.isEnabled(ActionsManager.ACTION_CONTINUE));
         am.postAction(ActionsManager.ACTION_CONTINUE);
@@ -189,7 +188,7 @@ public class DebuggerTest extends NbTestCase {
                       """);
 
         DebuggerManager manager = DebuggerManager.getDebuggerManager();
-        DAPLineBreakpoint breakpoint = DAPLineBreakpoint.create(testFileURL, 11);
+        DAPLineBreakpoint breakpoint = DAPLineBreakpoint.create(testFile, 11);
 
         breakpoint.setCondition("\"4\".equals(toPrint)");
         manager.addBreakpoint(breakpoint);
@@ -227,7 +226,6 @@ public class DebuggerTest extends NbTestCase {
              Writer w = new OutputStreamWriter(out)) {
             w.write(code);
         }
-        testFileURL = testFile.toURL().toString();
         try (OutputStream out = FileUtil.createData(project, "pom.xml").getOutputStream();
              Writer w = new OutputStreamWriter(out)) {
             w.write("""


### PR DESCRIPTION
- cleaning up use of String urls, using URIs internally
- cleaning up the breakpoint to not hold paths, but rather only hold FileObjects
- cleaning up the BreakpointAnnotationProvider to not use a weak listener, and holder for the listeners. Using ordinary listeners, which will be held as long as the DataObject exists, and should be automatically GCed when the DO is removed, which is presumably the intent
- renaming (DAP)Utils to DAPStackTraceAnnotationHolder